### PR TITLE
Fix hints for colored/albino attribute

### DIFF
--- a/services/eventRouter.js
+++ b/services/eventRouter.js
@@ -55,8 +55,9 @@ class EventRouter {
                     action.sequence
                 ));
                 session.logEvent(action);
-                BiologicaX.fixOutgoingEvent(action);
-                session.socket.emit(GuideProtocol.Event.Channel, action.toJson());
+
+                const actionJson = action.toJson(BiologicaX.fixOutgoingEvent);
+                session.socket.emit(GuideProtocol.Event.Channel, actionJson);
             } else {
                 Alert.debug("No tutoring action recommended.", session);
             }

--- a/shared/biologicax.js
+++ b/shared/biologicax.js
@@ -649,13 +649,11 @@ if (typeof exports === 'undefined') {
     // TODO rgtaylor 2018-09-21 This "workaround" should be removed in the future.
     // Workarounds necessary because data that Geniventure is expecting doesn't match the species
     // traitRules defined in Biologicajs.
-    BiologicaX.fixOutgoingEvent = function(event) {
-
-        if (event.hasOwnProperty('context') && event.context.hasOwnProperty('attribute')) {
-            if (event.context.attribute === "colored") {
-                event.context.attribute = "color";
-            }
+    BiologicaX.fixOutgoingEvent = function(key, value) {
+        if (key === "attribute" && value === "colored") {
+            return "color";
         }
+        return value;
     }
 
 }).call(this);

--- a/shared/guide-protocol.js
+++ b/shared/guide-protocol.js
@@ -53,8 +53,8 @@ if (typeof exports === 'undefined') {
         return this.actor + "-" + this.action + "-" + this.target;
     } 
 
-    GuideProtocol.Event.prototype.toJson = function() {
-        return JSON.stringify(this);
+    GuideProtocol.Event.prototype.toJson = function(replacer) {
+        return JSON.stringify(this, replacer);
     }   
 
     GuideProtocol.Event.fromJson = function(json) {


### PR DESCRIPTION
Fix hints for colored/albino attribute
- hintLevel wasn't incrementing properly
- `fixOutgoingEvent()` now fixes the outgoing event without modifying the internal event

The symptom was that the ITS kept recommending the level 1 hint without ever progressing to the level 2/3 hints or to remediation. This turned out to be because the `mostRecentHint` matching was failing due to a `color`/`colored` mismatch. With this change, `fixOutgoingEvent()` applies its transformation during stringification, which doesn't affect the original event.