### PR TITLE
Pull repository URL from package.json rather than hard-coding it

### DIFF
--- a/guide.js
+++ b/guide.js
@@ -114,6 +114,7 @@ const passportConfig = require('./config/passport');
  */
 const app = express();
 app.locals.version = guideInfo.version;
+app.locals.repository = guideInfo.repository;
 
 // Pretty print JSON
 app.set('json spaces', 2);

--- a/views/partials/footer.jade
+++ b/views/partials/footer.jade
@@ -3,8 +3,8 @@ footer
     //p.pull-left © 2016 North Carolina State University, Inc. All Rights Reserved
     ul.pull-right.list-inline
       li
-        a(href='https://github.com/IntelliMedia/guide-server') GitHub Project
+        a(href=repository.url || repository) GitHub Project
       li
-        a(href='https://github.com/IntelliMedia/guide-server/issues') Issues
+        a(href=(repository.url || repository) + '/issues') Issues
       li
         <span>#{version}</span>


### PR DESCRIPTION
Enables CC-hosted guide server to link to CC fork of guide server repo (after local changes to package.json).