### PR TITLE
Disable unused socket.io cookie to eliminate Chrome same-site cookie warning

### DIFF
--- a/guide.js
+++ b/guide.js
@@ -260,8 +260,9 @@ server.setTimeout(10*60*1000); // 10 * 60 seconds * 1000 msecs
 
 /**
  * Start WebSocket listener.
+ * cf. https://github.com/socketio/socket.io/issues/2276#issuecomment-553633888 for cookie setting
  */
-let io = socketManager.initialize(server);
+let io = socketManager.initialize(server, { cookie: false });
 app.set('socketio', io);
 
 module.exports = app;

--- a/services/socketManager.js
+++ b/services/socketManager.js
@@ -22,7 +22,8 @@ function  initializeV3(server) {
     let socketPath = process.env.BASE_PATH + "socket.io";
 
     var ioServer = socketio.listen(server, {
-        path: socketPath
+        path: socketPath,
+        cookie: false   // cf. https://github.com/socketio/socket.io/issues/2276#issuecomment-306448731
     });
     ioServer.on('connect_error', function(err) {
         handleConnectError(err);


### PR DESCRIPTION
See https://github.com/socketio/socket.io/issues/2276 for discussion, but the upshot is that the cookie is unused and can be disabled. There's discussion of two possible places to disable the cookie and one seemed to work for some and the other for others, so we specify `{ cookie: false }` in both.